### PR TITLE
Readme' installation part made more accurate

### DIFF
--- a/README
+++ b/README
@@ -18,8 +18,8 @@ LuaTeX you will need to replace /tex/latex by an appropriate path. Afterwards ru
 
     texhash 
 
-This command rebuilds TeX files database. After this your system should be able 
-recognize biblatex-iso690.
+This command rebuilds TeX files database. Now your system should be able 
+to work with biblatex-iso690.
 
 
 Usage:


### PR DESCRIPTION
Hi, I've tried to make more informative your Installation section in README file. It is not enough to create local texmf dir but you need to copy biblatex-iso690 package into appropriate path in order to be recognizable by TeX system
