### PR TITLE
Use `labelprefix` and not `prefixnumber`

### DIFF
--- a/iso-numeric.bbx
+++ b/iso-numeric.bbx
@@ -1,15 +1,16 @@
-\ProvidesFile{iso-numeric.bbx}[2011/06/08]
+\ProvidesFile{iso-numeric.bbx}[2016/03/12]
 
 \newbibmacro*{year-label}{}%
 \DeclareFieldFormat{labelnumberwidth}{#1\adddot}
 
 \newcommand\MethodFormat{%
-      \printtext[labelnumberwidth]{%
-    	\printfield{prefixnumber}%
-    	\printfield{labelnumber}}%
-    }%
-    \ExecuteBibliographyOptions{%
-       sorting=none
-      ,labelnumber
-    }
+  \printtext[labelnumberwidth]{%
+    \iffieldundef{labelprefix}{\printfield{prefixnumber}}{\printfield{labelprefix}}%
+    \printfield{labelnumber}}%
+}%
+
+\ExecuteBibliographyOptions{%
+   sorting=none
+  ,labelnumber
+}
 \RequireBibliographyStyle{iso}


### PR DESCRIPTION
Given the upcoming changes in `biblatex` 3.4 https://github.com/plk/biblatex/releases/tag/v3.4 we now need to print `labelprefix` and not `prefixnumber`. The change retains backwards compatibility and can be applied before biblatex 3.4 goes live.