### PR TITLE
Multiple creators -- final name 'and' delimiter; first creator + et al.

### DIFF
--- a/iso.bbx
+++ b/iso.bbx
@@ -79,7 +79,7 @@
 
 \renewcommand*\subtitlepunct{\addspcolon\space}
 \renewcommand\multinamedelim{\addsemicolon\addspace}
-%\renewcommand\intitlepunct{\addspace}
+\renewcommand\finalnamedelim{\multinamedelim}
 
 % Thanks Moewew for sugesting this. Make uppercase names only in biblipgraphy.
 % Default name format is ALL-CAPS

--- a/iso.bbx
+++ b/iso.bbx
@@ -78,10 +78,7 @@
 
 
 \renewcommand*\subtitlepunct{\addspcolon\space}
-\renewcommand\andmoredelim{\addcomma\addspace}
 \renewcommand\multinamedelim{\addsemicolon\addspace}
-%\renewcommand\finalnamedelim{\multinamedelim}
-\renewcommand\andothersdelim{\addcomma\addspace}
 %\renewcommand\intitlepunct{\addspace}
 
 % Thanks Moewew for sugesting this. Make uppercase names only in biblipgraphy.

--- a/iso.bbx
+++ b/iso.bbx
@@ -78,10 +78,10 @@
 
 
 \renewcommand*\subtitlepunct{\addspcolon\space}
-\renewcommand\andmoredelim{}
+\renewcommand\andmoredelim{\addcomma\addspace}
 \renewcommand\multinamedelim{\addsemicolon\addspace}
 %\renewcommand\finalnamedelim{\multinamedelim}
-\renewcommand\andothersdelim{\addspace}
+\renewcommand\andothersdelim{\addcomma\addspace}
 %\renewcommand\intitlepunct{\addspace}
 
 % Thanks Moewew for sugesting this. Make uppercase names only in biblipgraphy.

--- a/iso.bbx
+++ b/iso.bbx
@@ -35,8 +35,8 @@
 \ExecuteBibliographyOptions{%
   %spacecolon=true
    %sorting=nyt
-  ,maxnames=5
-  ,minnames=3
+  ,maxnames=9
+  ,minnames=1
 	,citetracker=true
   %,babel=other
   %,method=authoryear
@@ -80,7 +80,7 @@
 \renewcommand*\subtitlepunct{\addspcolon\space}
 \renewcommand\andmoredelim{}
 \renewcommand\multinamedelim{\addsemicolon\addspace}
-\renewcommand\finalnamedelim{\multinamedelim}
+%\renewcommand\finalnamedelim{\multinamedelim}
 \renewcommand\andothersdelim{\addspace}
 %\renewcommand\intitlepunct{\addspace}
 


### PR DESCRIPTION
According to ISO 690:2011, following changes are required:
* as a rule of thumb, all of the creators' names should be given if possible. In the case any names are omitted, the norm exclusively states that

   > the name of the first creator shall be given followed by “and others” or “et al.”.

   Let's assume the threshold of `maxnames` option to be nine.
* I can not manage to find exclusively stated in the norm the second point about **_and_** delimiter before the final name in a name list, but all of the examples provided there show it in this way. Hence I propose this change here.