### PR TITLE
The `babel` option was changed to `autolang` in BibLaTeX 2.8.

### DIFF
--- a/README
+++ b/README
@@ -36,7 +36,7 @@ Usage:
 \usepackage[
    backend=biber      % if we want unicode 
   ,style=iso-authoryear % or iso-numeric for numeric citation method          
-  ,babel=other        % to support multiple languages in bibliography
+  ,autolang=other     % to support multiple languages in bibliography
   ,sortlocale=cs_CZ   % locale of main language, it is for sorting
   ,bibencoding=UTF8   % this is necessary only if bibliography file is in different encoding than main document
 ]{biblatex}

--- a/bibpok.tex
+++ b/bibpok.tex
@@ -28,7 +28,7 @@
   ,autocite=footnote
   ,maxnames=5
   ,minnames=3
-  ,babel=other
+  ,autolang=other
   ,spacecolon=true
   ]
   {biblatex}

--- a/iso-example.tex
+++ b/iso-example.tex
@@ -15,7 +15,7 @@
 \usepackage[
    backend=biber
   ,style=iso-authoryear
-  ,babel=other
+  ,autolang=other
   ,sortlocale=cs_CZ
   ,bibencoding=UTF8
   ,spacecolon=true
@@ -58,7 +58,7 @@ Na vývoji stylu spolupracovali Johaness Bötchner, Moewew, Dávid Lupták a dal
    backend=biber
   ,style=iso-authoryear
   ,sortlocale=cs_CZ
-  ,babel=other
+  ,autolang=other
   ,bibencoding=UTF8
 ]{biblatex}
 \bibliography{souborsdatabazi}

--- a/iso.bbx
+++ b/iso.bbx
@@ -38,7 +38,7 @@
   ,maxnames=9
   ,minnames=1
 	,citetracker=true
-  %,babel=other
+  %,autolang=other
   %,method=authoryear
   ,date=year
   ,urldate=iso8601


### PR DESCRIPTION
The `babel` option is kept around for backwards compatibility, but it is deprecated (emits warnings).