### PR TITLE
Macro numeration for handling the respective stuff.

### DIFF
--- a/iso.bbx
+++ b/iso.bbx
@@ -163,6 +163,14 @@
 
 \DeclareNameAlias{default}{last-first}
 
+\newbibmacro*{numeration}{%
+  \printfield{volume}%
+  \setunit*{\addcomma\addspace}%
+  \printfield{number}%
+  \setunit*{\addcomma\addspace}%
+  \printfield{chapter}%
+}
+
 \newbibmacro*{book:pubinfo}{%
   %\iflistundef{location}{\printtext[colon]{\printlist{publisher}}}{%
   \iflistundef{publisher}{}{\printlist{location}\setunit{}}%
@@ -442,9 +450,7 @@
 \usebibmacro{article-date}
 %\usebibmacro{date-urldate}%
 \setunit*{\addcomma\addspace}%
-\printfield{volume}%
-\setunit*{\addcomma\addspace}%
-\printfield{number}%
+\usebibmacro{numeration}%
 \setunit*{\addcomma\addspace}%
 \printfield{pages}%
 \setunit*{\addspace}%
@@ -481,9 +487,9 @@
 \newunit\newblock%
 \usebibmacro{book:pubinfo}%
 \setunit*{\addcomma\addspace}%
+\usebibmacro{numeration}%
+\setunit*{\addcomma\addspace}%
 \printfield{pages}%
-\newunit\newblock%
-\printfield{chapter}%
 %\setunit*{\addcomma\addspace}%
 % \newunit%
 \newunit\newblock%
@@ -524,6 +530,8 @@
 % \newunit\newblock%
 % \printfield{number}%
 %\newunit\newblock
+\setunit*{\addcomma\addspace}%
+\usebibmacro{numeration}%
 \setunit*{\addcomma\addspace}%
 \printfield{pages}%
 %\usebibmacro{pagecount}%


### PR DESCRIPTION
Introduced in #35 comments, macro for the numeration stuff would be great deal. I've just collected there respective field, i.e. volume, number and chapter (in this order) which are mostly used.
The field pages is not included there, because the norm itself deals with this element separately as well.