### PR TITLE
\bibliography superseded by \addbibresource in BibLaTeX 1.2

### DIFF
--- a/bibpok.tex
+++ b/bibpok.tex
@@ -34,7 +34,7 @@
   {biblatex}
 %\usepackage[authordate]{biblatex-chicago}
 
-\bibliography{mybib}
+\addbibresource{mybib.bib}
 \begin{document}
 \nocite{*}
 Více isbn je třeba zadávat oddělené čárkou. Zpracovájí se pomocí makra docsvfield.

--- a/iso-authoryear.bbx
+++ b/iso-authoryear.bbx
@@ -13,7 +13,4 @@
 \RequireBibliographyStyle{iso}
 
 % remove second appearance of year in a reference
-\renewbibmacro*{date-urldate}{%
-  \usebibmacro{urldate}%
-}
-\renewbibmacro*{article-date}{}
+\renewbibmacro*{date}{}

--- a/iso-example.tex
+++ b/iso-example.tex
@@ -22,7 +22,7 @@
   ,spacecolon=true
   %,block=ragged
 ]{biblatex}
-\bibliography{mybib}
+\addbibresource{mybib.bib}
 \titlepage{%
   title={Styl ISO 690 pro biblatex},
   subtitle={},
@@ -62,7 +62,7 @@ Na vývoji stylu spolupracovali Johaness Bötchner, Moewew, Dávid Lupták a dal
   ,autolang=other
   ,bibencoding=UTF8
 ]{biblatex}
-\bibliography{souborsdatabazi}
+\addbibresource{menosouborusdatabazi.pripona}
 ..
 \printbibliography
 

--- a/iso.bbx
+++ b/iso.bbx
@@ -165,6 +165,11 @@
 \DeclareFieldFormat{urldate}{\mkbibbrackets{\mainsstring{urlseen}\space#1}}
 
 \DeclareFieldFormat{chapter}{\bibstring{chapter}~#1\isdot}
+\DeclareFieldFormat{version}{%
+  \ifnumeral{#1}%
+  {\biblstring{version}\addnbspace#1}%
+  {\MakeCapital{#1}}%
+}
 
 %\DeclareNameFormat{default}{%
 %\nameprint{#1}{#3}
@@ -184,31 +189,15 @@
   \printfield{chapter}%
 }
 
-\newbibmacro{totalpages}{%
-  \iftoggle{bbx:totalpages}
-    {\iffieldundef{pagetotal}
-      {}
-      {\printfield{pagetotal}%
-       \setunit*{\addspace}}}
-    {}
-}
-
-\newbibmacro*{book:pubinfo}{%
-  %\iflistundef{location}{\printtext[colon]{\printlist{publisher}}}{%
-  \iflistundef{publisher}{}{\printlist{location}\setunit{}}%
-  %    {\setunit*{\addcomma\addspace}}
-  %    {\setunit*{}}%
-  %}
-  \iflistundef{location}{\setunit{\adddot\addspace}}{%
-    % \iflistundef{publisher}{}{\printtext[colon]{\printlist{publisher}}}%
-    \iflistundef{publisher}{}{\setunit{\subtitlepunct}\printlist{publisher}}%
-  }%
-  %\printlist{publisher}%
-  \setunit*{\addcomma\addspace}%
-  \usebibmacro{date-urldate}%
-  \newunit%
-  \usebibmacro{totalpages}%
-}%
+\newbibmacro*{location+publisher+date}{%
+  \printlist{location}%
+  \iflistundef{publisher}
+    {\setunit*{\addcomma\space}}%
+    {\setunit*{\addcolon\space}}%
+  \printlist{publisher}%
+  \setunit*{\addcomma\space}%
+  \usebibmacro{date}%
+  \newunit}
 
 \newbibmacro*{names:primary}{%
   \ifnameundef{author}%
@@ -279,20 +268,6 @@
     {\usebibmacro{comment+link}{\printfield{howpublished}\usebibmacro{print-online}}}%
   }%
 }%
-
-% we can reset this macro in author year style so we don't print year twice
-% in reference
-% see section 4.2.4.3 of biblatex manual for details
-\newbibmacro*{date-urldate}{%
-  \usebibmacro{date}
-  \iffieldundef{urlyear}
-  {}
-  {\setunit*{\addspace}%
-  \usebibmacro{urldate}}
-}%
-
-% We should reset this macro in iso-authoreyear as well
-\newbibmacro*{article-date}{\usebibmacro{date}}
 
 \newbibmacro{book:vol}{%
 	\printfield{edition}%
@@ -448,10 +423,16 @@
 \newunit\newblock%
 \usebibmacro{book:vol}%
 \newunit\newblock%
-\usebibmacro{book:pubinfo}%
+\usebibmacro{location+publisher+date}%
+\newunit%
+\printfield{version}%
+\setunit{\addspace}%
+\usebibmacro{urldate}%
 \newunit\newblock%
-%\printfield{pagetotal}%
-%\newunit\newblock%
+\iftoggle{bbx:totalpages}
+  {\printfield{pagetotal}}
+  {}%
+\newunit\newblock%
 \printfield{series}%
 \newunit\newblock%
 \printfield{isbn}%
@@ -474,7 +455,7 @@
 \newunit\newblock
 \usebibmacro{book:vol}%
 \newunit\newblock%
-\usebibmacro{book:pubinfo}%
+\usebibmacro{location+publisher+date}%
 %\newunit\newblock
 %\usebibmacro{pagecount}%
 %\newunit\newblock%
@@ -510,15 +491,12 @@
 \newunit\newblock%
 \usebibmacro{book:vol}%
 \newunit\newblock%
-% \usebibmacro{book:pubinfo}%
-%\printfield{year}%
-\usebibmacro{article-date}
-%\usebibmacro{date-urldate}%
+\usebibmacro{date}
 \setunit*{\addcomma\addspace}%
 \usebibmacro{numeration}%
 \setunit*{\addcomma\addspace}%
 \printfield{pages}%
-\setunit*{\addspace}%
+\setunit{\addspace}%
 \usebibmacro{urldate}%
 \newunit\newblock%
 \printfield{issn}%
@@ -550,13 +528,15 @@
 \newunit\newblock%
 \usebibmacro{book:vol}%
 \newunit\newblock%
-\usebibmacro{book:pubinfo}%
+\usebibmacro{location+publisher+date}%
 \setunit*{\addcomma\addspace}%
 \usebibmacro{numeration}%
 \setunit*{\addcomma\addspace}%
 \printfield{pages}%
-%\setunit*{\addcomma\addspace}%
-% \newunit%
+\newunit%
+\printfield{version}%
+\setunit{\addspace}%
+\usebibmacro{urldate}%
 \newunit\newblock%
 \printfield{series}%
 \newunit\newblock%
@@ -589,17 +569,17 @@
 \newunit\newblock%
 \usebibmacro{book:vol}%
 \newunit\newblock%
-\usebibmacro{book:pubinfo}%
+\usebibmacro{location+publisher+date}%
 % could number be even used in `incollection`? 
 % It should be at some other place in this case
-% \newunit\newblock%
-% \printfield{number}%
-%\newunit\newblock
 \setunit*{\addcomma\addspace}%
 \usebibmacro{numeration}%
 \setunit*{\addcomma\addspace}%
 \printfield{pages}%
-%\usebibmacro{pagecount}%
+\newunit%
+\printfield{version}%
+\setunit{\addspace}%
+\usebibmacro{urldate}%
 \newunit\newblock%
 \printfield{series}%
 \newunit\newblock%
@@ -624,10 +604,15 @@
 \newunit\newblock%
 \usebibmacro{book:vol}%
 \newunit\newblock%
-\usebibmacro{book:pubinfo}%
+\usebibmacro{location+publisher+date}%
+\newunit%
+\printfield{version}%
+\setunit{\addspace}%
+\usebibmacro{urldate}%
 \newunit\newblock%
-%\printfield{pagetotal}%
-%\newunit\newblock%
+\iftoggle{bbx:totalpages}
+  {\printfield{pagetotal}}
+  {}%
 \printfield{series}%
 \newunit\newblock%
 \printfield{isbn}%

--- a/iso.bbx
+++ b/iso.bbx
@@ -4,9 +4,10 @@
 \NewBibliographyString{urlalso,urlcomercial}
 %options
 
-%switch space before colon in titles etc.
-\newboolean{bbx@tcolon}
-\DeclareBibliographyOption{spacecolon}[true]{\setboolean{bbx@tcolon}{#1}\typeout{Nastavuju: #1}}
+\newtoggle{bbx:spcolon}
+\DeclareBibliographyOption{spacecolon}[true]{%
+  \settoggle{bbx:spcolon}{#1}%
+  \typeout{Space colon enabled: #1}}
 
 \newboolean{bbx@totalpages}
 \DeclareBibliographyOption{pagetotal}[false]{\setboolean{bbx@totalpages}{#1}}
@@ -35,7 +36,7 @@
 % }
 
 \ExecuteBibliographyOptions{%
-  %spacecolon=true
+  spacecolon=false
    %sorting=nyt
   ,maxnames=9
   ,minnames=1
@@ -80,9 +81,15 @@
 % }
 
 
-\renewcommand*\subtitlepunct{\addspcolon\space}
+\renewcommand*\subtitlepunct{\addspacecolon\addspace}
 \renewcommand\multinamedelim{\addsemicolon\addspace}
 \renewcommand\finalnamedelim{\multinamedelim}
+
+\newcommand\addspacecolon{%
+  \iftoggle{bbx:spcolon}
+    {\addnbspace\blx@addsppunct{colon}}
+    {\unspace\blx@addsppunct{colon}}
+}
 
 % Thanks Moewew for sugesting this. Make uppercase names only in biblipgraphy.
 % Default name format is ALL-CAPS
@@ -182,7 +189,7 @@
   %}
   \iflistundef{location}{\setunit{\adddot\addspace}}{%
     % \iflistundef{publisher}{}{\printtext[colon]{\printlist{publisher}}}%
-    \iflistundef{publisher}{}{\setunit{\addspcolon\addspace}\printlist{publisher}}%
+    \iflistundef{publisher}{}{\setunit{\subtitlepunct}\printlist{publisher}}%
   }%
   %\printlist{publisher}%
   \setunit*{\addcomma\addspace}%
@@ -294,10 +301,9 @@
     \setunit{\addspace}%
     \printfield{#1addon}}}%
 
-% \makeatletter
 % see biblatex2.sty for these macros
 \blx@regimcs{% let biblatex know the new macros
-  \addspsemicolon \addspcolon \addcolon \addspcomma }%
+  \addspcolon }%
 \def\blx@addsppunct#1{% <---- new name for spaced punctuation
   %\unspace <----- commented out
   \ifnum\blx@spacefactor<\blx@sf@threshold@low
@@ -312,19 +318,16 @@
     \fi%
   \fi%
   \csuse{blx@pq@#1}}%
-% define new macros  
-% \protected\def\blx@imc@addspsemicolon{\blx@addsppunct{semicolon}}
-% \protected\def\blx@imc@addspcomma{\blx@addsppunct{comma}}
 
   \newbibmacro{totalpages}{}
 % declare new punctation
 % We must test for colonspace option at begin document
 \AtBeginDocument{%
-  \ifthenelse{\boolean{bbx@tcolon}}{%
-    \protected\def\blx@imc@addspcolon{\addnbspace\blx@addsppunct{colon}}%
-  }{%
-    \protected\def\blx@imc@addspcolon{\unspace\blx@addsppunct{colon}}%
-  }%
+  % \ifthenelse{\boolean{bbx@tcolon}}{%
+  %   \protected\def\blx@imc@addspcolon{\addnbspace\blx@addsppunct{colon}}%
+  % }{%
+  %   \protected\def\blx@imc@addspcolon{\unspace\blx@addsppunct{colon}}%
+  % }%
   \ifthenelse{\boolean{bbx@totalpages}}{%
     \renewbibmacro{totalpages}{%
       \iffieldundef{pagetotal}{}{%
@@ -334,10 +337,6 @@
     }
   }{}%
 }%
-%
-% \protected\def\blx@imc@addspcolon{\blx@addsppunct{colon}}
-% }{}%
-% \makeatother
 
 \newbibmacro{pub:title}{%
  \iffieldundef{maintitle}{%
@@ -507,7 +506,7 @@
 % \printfield{title}%
 % \printfield[colon]{subtitle}%
 \printfield{title}%
-\setunit{\addspcolon\addspace}%
+\setunit{\subtitlepunct}%
 \printfield{subtitle}%
 \setunit{\addspace}%
 \printfield{addon}%
@@ -545,7 +544,7 @@
 \usebibmacro{names:primary}%
 \setunit{\labelnamepunct}\newblock%
 \printfield{title}%
-\setunit{\addspcolon\addspace}%
+\setunit{\subtitlepunct}%
 \printfield{subtitle}%
 \setunit{\addspace}%
 \printfield{addon}%
@@ -584,7 +583,7 @@
 \usebibmacro{names:primary}%
 \setunit{\labelnamepunct}\newblock%
 \printfield{title}%
-\setunit{\addspcolon\addspace}%
+\setunit{\subtitlepunct}%
 \printfield{subtitle}%
 \setunit{\addspace}%
 \printfield{addon}%

--- a/iso.bbx
+++ b/iso.bbx
@@ -9,8 +9,10 @@
   \settoggle{bbx:spcolon}{#1}%
   \typeout{Space colon enabled: #1}}
 
-\newboolean{bbx@totalpages}
-\DeclareBibliographyOption{pagetotal}[false]{\setboolean{bbx@totalpages}{#1}}
+\newtoggle{bbx:totalpages}
+\DeclareBibliographyOption{pagetotal}[true]{%
+  \settoggle{bbx:totalpages}{#1}%
+  \typeout{Showing total pages enabled: #1}}
 
 % \newboolean{cbx@numeric}
 % \setboolean{cbx@numeric}{false}
@@ -37,6 +39,7 @@
 
 \ExecuteBibliographyOptions{%
   spacecolon=false
+  ,pagetotal=false
    %sorting=nyt
   ,maxnames=9
   ,minnames=1
@@ -181,6 +184,15 @@
   \printfield{chapter}%
 }
 
+\newbibmacro{totalpages}{%
+  \iftoggle{bbx:totalpages}
+    {\iffieldundef{pagetotal}
+      {}
+      {\printfield{pagetotal}%
+       \setunit*{\addspace}}}
+    {}
+}
+
 \newbibmacro*{book:pubinfo}{%
   %\iflistundef{location}{\printtext[colon]{\printlist{publisher}}}{%
   \iflistundef{publisher}{}{\printlist{location}\setunit{}}%
@@ -193,8 +205,9 @@
   }%
   %\printlist{publisher}%
   \setunit*{\addcomma\addspace}%
-  \usebibmacro{totalpages}%
   \usebibmacro{date-urldate}%
+  \newunit%
+  \usebibmacro{totalpages}%
 }%
 
 \newbibmacro*{names:primary}{%
@@ -318,25 +331,6 @@
     \fi%
   \fi%
   \csuse{blx@pq@#1}}%
-
-  \newbibmacro{totalpages}{}
-% declare new punctation
-% We must test for colonspace option at begin document
-\AtBeginDocument{%
-  % \ifthenelse{\boolean{bbx@tcolon}}{%
-  %   \protected\def\blx@imc@addspcolon{\addnbspace\blx@addsppunct{colon}}%
-  % }{%
-  %   \protected\def\blx@imc@addspcolon{\unspace\blx@addsppunct{colon}}%
-  % }%
-  \ifthenelse{\boolean{bbx@totalpages}}{%
-    \renewbibmacro{totalpages}{%
-      \iffieldundef{pagetotal}{}{%
-        \printfield{pagetotal}%
-        \setunit*{\addspace}%
-      }
-    }
-  }{}%
-}%
 
 \newbibmacro{pub:title}{%
  \iffieldundef{maintitle}{%


### PR DESCRIPTION
\bibliography command is still available for backwards compatibility, but it is deprecated.