### PR TITLE
Url + type of medium + identifiers

### DIFF
--- a/czech-iso.lbx
+++ b/czech-iso.lbx
@@ -1,4 +1,5 @@
 \ProvidesFile{czech-iso.lbx}
+[\abx@lbxid]
 
 \InheritBibliographyExtras{czech}
 \InheritBibliographyStrings{czech}
@@ -9,3 +10,5 @@
   urlalso = {{dostupn\'{e} tak\'{e} z}%
              {dostupn\'{e} tak\'{e} z}},
 }
+
+\endinput

--- a/czech-iso.lbx
+++ b/czech-iso.lbx
@@ -1,12 +1,11 @@
-
 \ProvidesFile{czech-iso.lbx}
 
 \InheritBibliographyExtras{czech}
 \InheritBibliographyStrings{czech}
 
 \DeclareBibliographyStrings{%
-  url = {{Do\-stup\-n\'y z~WWW}{WWW}},
-  urlalso={{Do\-stup\-n\'y tak\'e z~WWW}{WWW}}%,
-% this isn't used
-%  urlcomercial={{Do\-stup\-n\'y tak\'e komer\b{c}n\v{e} z~WWWW}{Komer\v{c}n\'i zdroj}}
+  urlfrom = {{dostupn\'{e} z}%
+             {dostupn\'{e} z}},
+  urlalso = {{dostupn\'{e} tak\'{e} z}%
+             {dostupn\'{e} tak\'{e} z}},
 }

--- a/english-iso.lbx
+++ b/english-iso.lbx
@@ -1,4 +1,5 @@
 \ProvidesFile{english-iso.lbx}
+[\abx@lbxid]
 
 \InheritBibliographyExtras{english}
 \InheritBibliographyStrings{english}
@@ -7,3 +8,5 @@
   urlalso = {{available also from}%
              {available also from}},
 }
+
+\endinput

--- a/english-iso.lbx
+++ b/english-iso.lbx
@@ -2,9 +2,8 @@
 
 \InheritBibliographyExtras{english}
 \InheritBibliographyStrings{english}
+
 \DeclareBibliographyStrings{%
-  url = {{Available from WWW}{WWW}},
-  urlalso={{Available also from WWW}{WWW}}%,
-%  this isn't used
-%  urlcomercial={{Available also commercially from WWWW}{Commercial source}}
+  urlalso = {{available also from}%
+             {available also from}},
 }

--- a/iso.bbx
+++ b/iso.bbx
@@ -130,7 +130,11 @@
 }%
 \DeclareFieldFormat*{pages}{\mainsstring{pages}\space\printtext{#1}}
 \DeclareFieldFormat*{number}{\bibsstring{number}\addspace\printtext{#1}}
-\DeclareFieldFormat*{url}{\url{#1}}
+\DeclareFieldFormat*{url}{%
+  \iffieldundef{urlyear}
+  {\mainlstring{urlalso}\addcolon\space\url{#1}}
+  {\mainlstring{urlfrom}\addcolon\space\url{#1}}
+}
 \DeclareFieldFormat*{doi}{\url{http://dx.doi.org/#1}}
 
 \DeclareFieldFormat{sbrackets}{[#1]}
@@ -230,28 +234,23 @@
   \printtext{#1}\setunit*{\addcolon\addspace}%\printtext[rbrackets]{#2}%
 }%
 \newbibmacro{print-online}{%
-  \printtext[rbrackets]{%
-    \usebibmacro{online-test}{}{%
-      \iffieldundef{url}{%
-        \printfield{doi}%
-        \printfield{eprint}%
-      }%
-      {\printfield{url}}%
+  \usebibmacro{online-test}
+  {}
+  {\iffieldundef{url}
+    {
+      \printfield{doi}%
+      \printfield{eprint}%
     }%
+    {\printfield{url}}%
   }%
 }%
-
-\newbibmacro{urlinfo}{%
-  \iffieldundef{urlyear}{\mainlstring{urlalso}}{\mainlstring{url}}%
-}%
-
 
 \newbibmacro{availability}{%
   % test for url, eprint and doi fields
   \usebibmacro{online-test}%
   {}%
   {\iffieldundef{howpublished}% when some of them is used
-    {\usebibmacro{comment+link}{\usebibmacro{urlinfo}}\usebibmacro{print-online}}%
+    {\usebibmacro{print-online}}%
     {\usebibmacro{comment+link}{\printfield{howpublished}\usebibmacro{print-online}}}%
   }%
 }%
@@ -567,8 +566,8 @@
 \newunit\newblock%
 \printfield{isbn}%
 \newunit\newblock%
-%\usebibmacro{availability}%
-\usebibmacro{comment+link}{\mainlstring{url}}\usebibmacro{print-online}%
+\usebibmacro{availability}%
+%\usebibmacro{comment+link}{\mainlstring{url}}\usebibmacro{print-online}%
 \newunit\newblock%
 \printfield{note}%
 \newunit\newblock%

--- a/iso.bbx
+++ b/iso.bbx
@@ -141,6 +141,12 @@
     {\href{http://dx.doi.org/#1}{\nolinkurl{#1}}}
     {\nolinkurl{#1}}
 }
+\DeclareFieldFormat{howpublished}{\mkbibbrackets{#1}}
+\DeclareFieldFormat[online]{howpublished}{%
+  \iffieldundef{howpublished}
+    {\mkbibbrackets{online}}
+    {\mkbibbrackets{#1}}
+}
 
 \DeclareFieldFormat{sbrackets}{[#1]}
 %\DeclareFieldFormat{rbrackets}{\printtext{$\langle$}#1\printtext{$\rangle$}}
@@ -230,11 +236,13 @@
 %   {#2}%
 % }%
 
-\newbibmacro*{online}{%
-  %\def\online{}%
-  \iffieldundef{urlyear}{}{\printtext[sbrackets]{online}}%
-  %\usebibmacro{online-test}{}{\online}%
-}%
+\newbibmacro*{medium-type}{%
+  \iffieldundef{howpublished}
+    {\iffieldundef{urlyear}
+      {}
+      {\printtext{\mkbibbrackets{online}}}}
+    {\printfield{howpublished}}
+}
 
 % \newbibmacro{comment+link}[1]{%
 %   \printtext{#1}\setunit*{\addcolon\addspace}%\printtext[rbrackets]{#2}%
@@ -361,11 +369,11 @@
  }{%
   \usebibmacro{titles}{main}%
  }%
- \usebibmacro{online}%
+ \usebibmacro{medium-type}%
 }%
 \newbibmacro{jour:title}{%
 \usebibmacro{titles}{journal}%
-\usebibmacro{online}%
+\usebibmacro{medium-type}%
 }
 
 \DeclareFieldFormat{journaltitle}{#1}

--- a/iso.bbx
+++ b/iso.bbx
@@ -164,6 +164,11 @@
 \renewcommand*{\do}[1]{\printtext{ISSN}\addnbspace#1\adddot\addspace}%
 \docsvfield{issn}}%
 
+\DeclareFieldFormat{isan}{\printtext{ISAN}\addnbspace#1}
+\DeclareFieldFormat{ismn}{\printtext{ISMN}\addnbspace#1}
+\DeclareFieldFormat{isrn}{\printtext{ISRN}\addnbspace#1}
+\DeclareFieldFormat{iswc}{\printtext{ISWC}\addnbspace#1}
+
 \DeclareFieldFormat{urldate}{\mkbibbrackets{\mainsstring{urlseen}\space#1}}
 
 \DeclareFieldFormat{chapter}{\bibstring{chapter}~#1\isdot}
@@ -283,6 +288,21 @@
        {\printfield{url}}
        {\usebibmacro{from-eprint}}}
     {\usebibmacro{from-doi}}
+}
+
+\newbibmacro*{identifier}{%
+  \printfield{isan}%
+  \newunit%
+  \printfield{isbn}%
+  \newunit%
+  \printfield{ismn}%
+  \newunit%
+  \printfield{isrn}%
+  \newunit%
+  \printfield{issn}%
+  \newunit%
+  \printfield{iswc}%
+  \newunit%
 }
 
 % we can reset this macro in author year style so we don't print year twice
@@ -418,7 +438,7 @@
 \newunit\newblock%
 \printfield{series}%
 \newunit\newblock%
-\printfield{isbn}%
+\usebibmacro{identifier}%
 \newunit\newblock%
 \usebibmacro{availability+access}%
 \newunit\newblock%
@@ -445,7 +465,7 @@
 %\printfield{series}%
 %\usebibmacro{print-online}{\mainlstring{url}}{\printfield{url}}%
 \newunit\newblock%
-\printfield{issn}%
+\usebibmacro{identifier}%
 \newunit\newblock%
 \usebibmacro{availability+access}%
 \newunit\newblock%
@@ -485,7 +505,7 @@
 \setunit*{\addspace}%
 \usebibmacro{urldate}%
 \newunit\newblock%
-\printfield{issn}%
+\usebibmacro{identifier}%
 \newunit\newblock%
 \usebibmacro{availability+access}%
 \newunit\newblock%
@@ -524,7 +544,7 @@
 \newunit\newblock%
 \printfield{series}%
 \newunit\newblock%
-\printfield{isbn}%
+\usebibmacro{identifier}%
 \newunit\newblock%
 \usebibmacro{availability+access}%
 \newunit\newblock%
@@ -567,7 +587,7 @@
 \newunit\newblock%
 \printfield{series}%
 \newunit\newblock%
-\printfield{isbn}%
+\usebibmacro{identifier}%
 \newunit\newblock%
 \usebibmacro{availability+access}%
 \newunit\newblock%
@@ -594,7 +614,7 @@
 \newunit\newblock%
 \printfield{series}%
 \newunit\newblock%
-\printfield{isbn}%
+\usebibmacro{identifier}%
 \newunit\newblock%
 \usebibmacro{availability+access}%
 %\usebibmacro{comment+link}{\mainlstring{url}}\usebibmacro{print-online}%

--- a/iso.bbx
+++ b/iso.bbx
@@ -135,7 +135,12 @@
   {\mainlstring{urlalso}\addcolon\space\url{#1}}
   {\mainlstring{urlfrom}\addcolon\space\url{#1}}
 }
-\DeclareFieldFormat*{doi}{\url{http://dx.doi.org/#1}}
+\DeclareFieldFormat{doi}{%
+  \printtext{DOI}\addcolon\space%
+  \ifhyperref
+    {\href{http://dx.doi.org/#1}{\nolinkurl{#1}}}
+    {\nolinkurl{#1}}
+}
 
 \DeclareFieldFormat{sbrackets}{[#1]}
 %\DeclareFieldFormat{rbrackets}{\printtext{$\langle$}#1\printtext{$\rangle$}}
@@ -213,47 +218,64 @@
 }%
 
 
-\newbibmacro*{online-test}[2]{%
-  \ifboolexpr{%
-    test {\iffieldundef{url}}%
-    and%
-    test {\iffieldundef{eprint}}%
-    and%
-    test {\iffieldundef{doi}}%
-  }%
-  {#1}%
-  {#2}%
-}%
+% \newbibmacro*{online-test}[2]{%
+%   \ifboolexpr{%
+%     test {\iffieldundef{url}}%
+%     and%
+%     test {\iffieldundef{eprint}}%
+%     and%
+%     test {\iffieldundef{doi}}%
+%   }%
+%   {#1}%
+%   {#2}%
+% }%
+
 \newbibmacro*{online}{%
   %\def\online{}%
   \iffieldundef{urlyear}{}{\printtext[sbrackets]{online}}%
   %\usebibmacro{online-test}{}{\online}%
 }%
 
-\newbibmacro{comment+link}[1]{%
-  \printtext{#1}\setunit*{\addcolon\addspace}%\printtext[rbrackets]{#2}%
-}%
-\newbibmacro{print-online}{%
-  \usebibmacro{online-test}
-  {}
-  {\iffieldundef{url}
-    {
-      \printfield{doi}%
-      \printfield{eprint}%
-    }%
-    {\printfield{url}}%
-  }%
-}%
+% \newbibmacro{comment+link}[1]{%
+%   \printtext{#1}\setunit*{\addcolon\addspace}%\printtext[rbrackets]{#2}%
+% }%
+% \newbibmacro{print-online}{%
+%   \usebibmacro{online-test}
+%   {}
+%   {\iffieldundef{url}
+%     {
+%       \printfield{doi}%
+%       \printfield{eprint}%
+%     }%
+%     {\printfield{url}}%
+%   }%
+% }%
 
-\newbibmacro{availability}{%
-  % test for url, eprint and doi fields
-  \usebibmacro{online-test}%
-  {}%
-  {\iffieldundef{howpublished}% when some of them is used
-    {\usebibmacro{print-online}}%
-    {\usebibmacro{comment+link}{\printfield{howpublished}\usebibmacro{print-online}}}%
-  }%
-}%
+% \newbibmacro{availability}{%
+%   % test for url, eprint and doi fields
+%   \usebibmacro{online-test}%
+%   {}%
+%   {\iffieldundef{howpublished}% when some of them is used
+%     {\usebibmacro{print-online}}%
+%     {\usebibmacro{comment+link}{\printfield{howpublished}\usebibmacro{print-online}}}%
+%   }%
+% }%
+
+\newbibmacro*{from-doi}{%
+  \mainlstring{urlfrom}\addspace\printfield{doi}%
+}
+
+\newbibmacro*{from-eprint}{%
+  \mainlstring{urlfrom}\addspace\usebibmacro{eprint}%
+}
+
+\newbibmacro*{availability+access}{%
+  \iffieldundef{doi}
+    {\iffieldundef{eprint}
+       {\printfield{url}}
+       {\usebibmacro{from-eprint}}}
+    {\usebibmacro{from-doi}}
+}
 
 % we can reset this macro in author year style so we don't print year twice
 % in reference
@@ -390,7 +412,7 @@
 \newunit\newblock%
 \printfield{isbn}%
 \newunit\newblock%
-\usebibmacro{availability}%
+\usebibmacro{availability+access}%
 \newunit\newblock%
 \printfield{note}%
 \newunit\newblock%
@@ -417,7 +439,7 @@
 \newunit\newblock%
 \printfield{issn}%
 \newunit\newblock%
-\usebibmacro{availability}%
+\usebibmacro{availability+access}%
 \newunit\newblock%
 \printfield{note}%
 \newunit\newblock%
@@ -457,7 +479,7 @@
 \newunit\newblock%
 \printfield{issn}%
 \newunit\newblock%
-\usebibmacro{availability}%
+\usebibmacro{availability+access}%
 \newunit\newblock%
 \printfield{note}%
 \setunit{\bibpagerefpunct}\newblock%
@@ -496,7 +518,7 @@
 \newunit\newblock%
 \printfield{isbn}%
 \newunit\newblock%
-\usebibmacro{availability}%
+\usebibmacro{availability+access}%
 \newunit\newblock%
 \printfield{note}%
 \newunit\newblock%
@@ -539,7 +561,7 @@
 \newunit\newblock%
 \printfield{isbn}%
 \newunit\newblock%
-\usebibmacro{availability}%
+\usebibmacro{availability+access}%
 \newunit\newblock%
 \printfield{note}%
 \newunit\newblock%
@@ -566,7 +588,7 @@
 \newunit\newblock%
 \printfield{isbn}%
 \newunit\newblock%
-\usebibmacro{availability}%
+\usebibmacro{availability+access}%
 %\usebibmacro{comment+link}{\mainlstring{url}}\usebibmacro{print-online}%
 \newunit\newblock%
 \printfield{note}%


### PR DESCRIPTION
Well, stuff regarding availability of resources needed better handling, i.e.
* `urlfrom` and `urlalso` differentiation on more proper place,
* doi or eprint identifiers takes precedence over url address (according the norm)
  * I do not exactly know why there was so robust testing on `url`, `doi` and `eprint` fields, hence I have just commented respective macros out, not deleting them
  * I have redeclared just `doi` field (and just a little bit) and not also `eprint`, because `eprint` default handling is really nice, imho
* correction of `howpublished` field as a type of medium, because it was not working properly
* and defining one macro for all standard identifiers available by biblatex package
  * I am not sure I understand how the handling of multiple ISSNs works, because I suppose if there is `issn = {number1, number2}` in .bib file, the output would be something like `..text. ISSN number1. ISSN number2. Text..`. Now it prints `..text. ISSN number1, number2. ISSN number1, number2. Text..`. Am I missing something?
