### PR TITLE
Omission of numeration and pagination terms.

### DIFF
--- a/iso.bbx
+++ b/iso.bbx
@@ -133,11 +133,11 @@
 \DeclareFieldFormat*{title}{#1}
 \DeclareFieldFormat*{subtitle}{#1}
 \DeclareFieldFormat*{chapter}{#1}
-\DeclareFieldFormat{volume}{\bibsstring{volume}~#1}% volume of a book
+\DeclareFieldFormat{volume}{\bibsstring{volume}\addnbspace#1}% volume of a book
 \DeclareFieldFormat[article,periodical]{volume}{%
   \iftoggle{bbx:shortnum}
     {\mkbibbold{#1}}
-    {\bibsstring{jourvol}~#1}% volume of a journal
+    {\bibsstring{jourvol}\addnbspace#1}% volume of a journal
 }
 \DeclareFieldFormat*{emphatize}{\emph{#1}}
 \DeclareFieldFormat*{edition}{%
@@ -184,7 +184,7 @@
 
 \DeclareFieldFormat{urldate}{\mkbibbrackets{\mainsstring{urlseen}\space#1}}
 
-\DeclareFieldFormat{chapter}{\bibstring{chapter}~#1\isdot}
+\DeclareFieldFormat{chapter}{\bibstring{chapter}\addnbspace#1\isdot}
 \DeclareFieldFormat{version}{%
   \ifnumeral{#1}%
   {\biblstring{version}\addnbspace#1}%

--- a/iso.bbx
+++ b/iso.bbx
@@ -14,6 +14,11 @@
   \settoggle{bbx:totalpages}{#1}%
   \typeout{Showing total pages enabled: #1}}
 
+\newtoggle{bbx:shortnum}
+\DeclareBibliographyOption{shortnumeration}[true]{%
+  \settoggle{bbx:shortnum}{#1}%
+  \typeout{Short numeration enabled: #1}}
+
 % \newboolean{cbx@numeric}
 % \setboolean{cbx@numeric}{false}
 % \newbibmacro*{year-label}{}
@@ -40,6 +45,7 @@
 \ExecuteBibliographyOptions{%
   spacecolon=false
   ,pagetotal=false
+  ,shortnumeration=true
    %sorting=nyt
   ,maxnames=9
   ,minnames=1
@@ -128,7 +134,11 @@
 \DeclareFieldFormat*{subtitle}{#1}
 \DeclareFieldFormat*{chapter}{#1}
 \DeclareFieldFormat{volume}{\bibsstring{volume}~#1}% volume of a book
-\DeclareFieldFormat[article,periodical]{volume}{\bibsstring{jourvol}~#1}% volume of a journal
+\DeclareFieldFormat[article,periodical]{volume}{%
+  \iftoggle{bbx:shortnum}
+    {\mkbibbold{#1}}
+    {\bibsstring{jourvol}~#1}% volume of a journal
+}
 \DeclareFieldFormat*{emphatize}{\emph{#1}}
 \DeclareFieldFormat*{edition}{%
   \ifnumeral{#1}%
@@ -140,9 +150,19 @@
     \MakeCapital{#1}}%}}%
 }%
 % \DeclareFieldFormat*{pages}{\mkmlpageprefix[bookpagination]{#1}}
-\DeclareFieldFormat*{pages}{\mainsstring{pages}\addspace\printtext{#1}}
+\DeclareFieldFormat{pages}{\mainsstring{pages}\addspace\printtext{#1}}
+\DeclareFieldFormat[article,periodical]{pages}{%
+  \iftoggle{bbx:shortnum}
+    {#1}
+    {\mainsstring{pages}\addspace\printtext{#1}}
+}
 \DeclareFieldFormat*{pagetotal}{\mkmlpagetotal[bookpagination]{#1}}
-\DeclareFieldFormat*{number}{\bibsstring{number}\addspace\printtext{#1}}
+\DeclareFieldFormat{number}{\bibsstring{number}\addspace\printtext{#1}}
+\DeclareFieldFormat[article,periodical]{number}{%
+  \iftoggle{bbx:shortnum}
+    {\mkbibparens{#1}}
+    {\bibsstring{number}\addspace\printtext{#1}}
+}
 \DeclareFieldFormat*{url}{\url{#1}}
 \DeclareFieldFormat*{doi}{\url{http://dx.doi.org/#1}}
 
@@ -183,7 +203,9 @@
 
 \newbibmacro*{numeration}{%
   \printfield{volume}%
-  \setunit*{\addcomma\addspace}%
+  \iftoggle{bbx:shortnum}
+    {}
+    {\setunit*{\addcomma\addspace}}%
   \printfield{number}%
   \setunit*{\addcomma\addspace}%
   \printfield{chapter}%


### PR DESCRIPTION
This could be the best resolution of all of the problems regarding the multilingual stuff, thanks to the section 10.3 of the norm

> The term “volume” and terms for smaller components of a serial publication may be omitted and the numbers distinguished typographically, with the volume number in bold type and the part number, if required, in parentheses.

It's set to be the default option for handling numeration stuff.