### PR TITLE
Titles refactoring

### DIFF
--- a/iso.bbx
+++ b/iso.bbx
@@ -352,8 +352,8 @@
 %   \printfield[emphatize]{#1addon}%
 % }
 
-\newbibmacro{titles}[1]{%
-  \printtext[emphatize]{%
+\newbibmacro{titles}[2]{%
+  \printtext[#2]{%
     \printfield{#1title}%
     \setunit{\subtitlepunct}%
     \printfield{#1subtitle}%
@@ -378,33 +378,23 @@
   \fi%
   \csuse{blx@pq@#1}}%
 
-\newbibmacro{pub:title}{%
- \iffieldundef{maintitle}{%
-  \iffieldundef{booktitle}{%
-    \usebibmacro{titles}{}%
-  }{%
-    \usebibmacro{titles}{book}%
-  }%
- }{%
-  \usebibmacro{titles}{main}%
- }%
- \usebibmacro{medium-type}%
+\newbibmacro{host:titles}{%
+ \iffieldundef{maintitle}
+   {\iffieldundef{booktitle}
+      {}
+      {\usebibmacro{titles}{book}{emph}}}
+   {\usebibmacro{titles}{main}{emph}}
 }%
-\newbibmacro{jour:title}{%
-\usebibmacro{titles}{journal}%
-\usebibmacro{medium-type}%
-}
 
-\newbibmacro{periodical:title}{%
-  \printfield{title}%
+\newbibmacro{periodical:titles}{%
+  \usebibmacro{titles}{}{}%
+  \newunit%
   \iffieldundef{issuetitle}
     {\iffieldundef{journaltitle}
        {}
-       {\usebibmacro{titles}{journal}}}
-    {\usebibmacro{titles}{issue}}
-  \usebibmacro{medium-type}%
+       {\usebibmacro{titles}{journal}{emph}}}
+    {\usebibmacro{titles}{issue}{emph}}
 }
-
 
 \DeclareFieldFormat{journaltitle}{#1}
 \DeclareFieldFormat{booktitle}{#1}
@@ -503,7 +493,9 @@
 %\printnames{author}%
 \usebibmacro{names:primary}%
 \setunit{\labelnamepunct}\newblock%%
-\usebibmacro{pub:title}%
+\usebibmacro{titles}{}{emph}%
+\setunit{\addspace}%
+\usebibmacro{medium-type}%
 \newunit\newblock%
 \usebibmacro{book:vol}%
 \newunit\newblock%
@@ -535,7 +527,9 @@
 %\printnames{author}%
 %\usebibmacro{names:primary}%
 \newunit\newblock%
-\usebibmacro{periodical:title}%
+\usebibmacro{periodical:titles}%
+\setunit{\addspace}%
+\usebibmacro{medium-type}%
 \newunit\newblock
 \usebibmacro{book:vol}%
 \newunit\newblock%
@@ -564,14 +558,11 @@
 \setunit{\labelnamepunct}\newblock%
 % \printfield{title}%
 % \printfield[colon]{subtitle}%
-\printfield{title}%
-\setunit{\subtitlepunct}%
-\printfield{subtitle}%
-\setunit{\addspace}%
-\printfield{addon}%
+\usebibmacro{titles}{}{}%
 \newunit\newblock%
-\usebibmacro{jour:title}%
-%\printfield[emphatize]{journaltitle}%%
+\usebibmacro{titles}{journal}{emph}%
+\setunit{\addspace}%
+\usebibmacro{medium-type}%
 \newunit\newblock%
 \usebibmacro{book:vol}%
 \newunit\newblock%
@@ -599,16 +590,14 @@
 \usebibmacro{begentry}%
 \usebibmacro{names:primary}%
 \setunit{\labelnamepunct}\newblock%
-\printfield{title}%
-\setunit{\subtitlepunct}%
-\printfield{subtitle}%
-\setunit{\addspace}%
-\printfield{addon}%
+\usebibmacro{titles}{}{}%
 \newunit\newblock%
 \usebibmacro{in:}%
 \printnames{bookauthor}%
 \newunit\newblock%
-\usebibmacro{pub:title}%
+\usebibmacro{host:titles}%
+\setunit{\addspace}%
+\usebibmacro{medium-type}%
 \newunit\newblock%
 \usebibmacro{book:vol}%
 \newunit\newblock%
@@ -640,16 +629,14 @@
 \usebibmacro{begentry}%
 \usebibmacro{names:primary}%
 \setunit{\labelnamepunct}\newblock%
-\printfield{title}%
-\setunit{\subtitlepunct}%
-\printfield{subtitle}%
-\setunit{\addspace}%
-\printfield{addon}%
+\usebibmacro{titles}{}{}%
 \newunit\newblock%
 \usebibmacro{in:}%
 \usebibmacro{editor}%
 \newunit\newblock%
-\usebibmacro{pub:title}%
+\usebibmacro{host:titles}%
+\setunit{\addspace}%
+\usebibmacro{medium-type}%
 \newunit\newblock%
 \usebibmacro{book:vol}%
 \newunit\newblock%
@@ -684,7 +671,9 @@
 %\printnames{author}%
 \usebibmacro{names:primary}%
 \setunit{\labelnamepunct}\newblock%
-\usebibmacro{pub:title}%
+\usebibmacro{titles}{}{emph}%
+\setunit{\addspace}%
+\usebibmacro{medium-type}%
 \newunit\newblock%
 \usebibmacro{book:vol}%
 \newunit\newblock%

--- a/iso.bbx
+++ b/iso.bbx
@@ -149,8 +149,7 @@
     %    \ifstrequal{#1}{third}{\mkbibordedition{3}}{
     \MakeCapital{#1}}%}}%
 }%
-% \DeclareFieldFormat*{pages}{\mkmlpageprefix[bookpagination]{#1}}
-\DeclareFieldFormat*{pages}{\mainsstring{pages}\addspace\printtext{#1}}
+\DeclareFieldFormat*{pages}{\mkmlpageprefix[bookpagination]{#1}}
 \DeclareFieldFormat[article,periodical]{pages}{%
   \iftoggle{bbx:shortnum}
     {#1}

--- a/iso.bbx
+++ b/iso.bbx
@@ -395,12 +395,25 @@
 \usebibmacro{medium-type}%
 }
 
+\newbibmacro{periodical:title}{%
+  \printfield{title}%
+  \iffieldundef{issuetitle}
+    {\iffieldundef{journaltitle}
+       {}
+       {\usebibmacro{titles}{journal}}}
+    {\usebibmacro{titles}{issue}}
+  \usebibmacro{medium-type}%
+}
+
+
 \DeclareFieldFormat{journaltitle}{#1}
 \DeclareFieldFormat{booktitle}{#1}
 \DeclareFieldFormat{maintitle}{#1}
+\DeclareFieldFormat{issuetitle}{#1}
 \DeclareFieldFormat{journalsubtitle}{#1}
 \DeclareFieldFormat{booksubtitle}{#1}
 \DeclareFieldFormat{mainsubtitle}{#1}
+\DeclareFieldFormat{issuesubtitle}{#1}
 
 % redeclare in: bibmacro to use the main document language.
 % there was discussion whether literal "In:" should be used,
@@ -522,7 +535,7 @@
 %\printnames{author}%
 %\usebibmacro{names:primary}%
 \newunit\newblock%
-\usebibmacro{jour:title}%
+\usebibmacro{periodical:title}%
 \newunit\newblock
 \usebibmacro{book:vol}%
 \newunit\newblock%

--- a/iso.bbx
+++ b/iso.bbx
@@ -356,8 +356,10 @@
     \printfield{#1title}%
     \setunit{\subtitlepunct}%
     \printfield{#1subtitle}%
-    \setunit{\addspace}%
-    \printfield{#1addon}}}%
+  }
+  \setunit{\addspace}%
+  \printfield{#1titleaddon}%
+}%
 
 % see biblatex2.sty for these macros
 \blx@regimcs{% let biblatex know the new macros
@@ -405,6 +407,10 @@
 \DeclareFieldFormat{booksubtitle}{#1}
 \DeclareFieldFormat{mainsubtitle}{#1}
 \DeclareFieldFormat{issuesubtitle}{#1}
+
+\DeclareFieldFormat{titleaddon}{\mkbibbrackets{#1}}
+\DeclareFieldFormat{booktitleaddon}{\mkbibbrackets{#1}}
+\DeclareFieldFormat{maintitleaddon}{\mkbibbrackets{#1}}
 
 % redeclare in: bibmacro to use the main document language.
 % there was discussion whether literal "In:" should be used,

--- a/iso.bbx
+++ b/iso.bbx
@@ -386,8 +386,10 @@
 }%
 
 \newbibmacro{periodical:titles}{%
-  \usebibmacro{titles}{}{}%
-  \newunit%
+  \iffieldundef{title}
+    {}
+    {\usebibmacro{titles}{}{}%
+     \newunit}
   \iffieldundef{issuetitle}
     {\iffieldundef{journaltitle}
        {}

--- a/iso.bbx
+++ b/iso.bbx
@@ -15,7 +15,7 @@
   \typeout{Showing total pages enabled: #1}}
 
 \newtoggle{bbx:shortnum}
-\DeclareBibliographyOption{shortnumeration}[false]{%
+\DeclareBibliographyOption{shortnumeration}[true]{%
   \settoggle{bbx:shortnum}{#1}%
   \typeout{Short numeration enabled: #1}}
 

--- a/iso.bbx
+++ b/iso.bbx
@@ -280,7 +280,7 @@
     {\iffieldundef{urlyear}
       {}
       {\printtext{\mkbibbrackets{online}}}}
-    {\printfield{howpublished}}
+    {\printfield{howpublished}}%
 }
 
 % \newbibmacro{comment+link}[1]{%
@@ -321,7 +321,7 @@
     {\iffieldundef{eprint}
        {\printfield{url}}
        {\usebibmacro{from-eprint}}}
-    {\usebibmacro{from-doi}}
+    {\usebibmacro{from-doi}}%
 }
 
 \newbibmacro*{identifier}{%
@@ -384,19 +384,19 @@
    {\iffieldundef{booktitle}
       {}
       {\usebibmacro{titles}{book}{emph}}}
-   {\usebibmacro{titles}{main}{emph}}
+   {\usebibmacro{titles}{main}{emph}}%
 }%
 
 \newbibmacro{periodical:titles}{%
   \iffieldundef{title}
     {}
     {\usebibmacro{titles}{}{}%
-     \newunit}
+     \newunit}%
   \iffieldundef{issuetitle}
     {\iffieldundef{journaltitle}
        {}
        {\usebibmacro{titles}{journal}{emph}}}
-    {\usebibmacro{titles}{issue}{emph}}
+    {\usebibmacro{titles}{issue}{emph}}%
 }
 
 \DeclareFieldFormat{journaltitle}{#1}


### PR DESCRIPTION
Titles related macros needed refactoring as well, so here it is:
* macro `pub:title` handled some checking on `maintitle` and `booktitle`, which was causing problems e.g. with `knuth:ct` works (addressing #19 -- [at the end of this comment](https://github.com/michal-h21/biblatex-iso690/issues/19#issuecomment-139738188))
  * according the norm and the basic principle of determining the appropriate level of specificity at which the reference is made, the `maintitle` or `booktitle` is not worth to print if it is related to `@book` entry type. Hence `title` is enough.
  * `pub:title` has been renamed to `host:titles` and rewritten to be applied to use for printing host item (book, collection, etc.) of the reference.
* `medium-type` macro has been extracted as a separate macro into the drivers
* titles of `@periodical` entry types are handled as follows:
  * Title. [_Issuetitle_ | _Journaltitle_].
* two arguments instead of one are passed into `titles` macro, for avoiding duplication of the code