### PR TITLE
Make numeric bibliography style visually compatible with non-iso styles.

### DIFF
--- a/iso-numeric.bbx
+++ b/iso-numeric.bbx
@@ -21,8 +21,7 @@
 \defbibenvironment{bibliography}
   {\list%
      {\MethodFormat}%
-     {\setlength{\leftmargin}{\bibhang}%
-      \setlength{\itemindent}{-\leftmargin}%
+     {\setlength{\leftmargin}{\labelnumberwidth}%
       \setlength{\itemsep}{\bibitemsep}%
       \setlength{\parsep}{\bibparsep}}%
       \renewcommand*{\makelabel}[1]{\hss##1}


### PR DESCRIPTION
The `iso-numeric` bibliography style has the labels hanging into the left margin. I think it would be better to not have the labels hang by default, as is tends to look out of place in most documents:

![fix](https://cloud.githubusercontent.com/assets/603082/25315197/8f939896-2851-11e7-8436-2bf4ceecbc4a.png)

If changing the style is not an option, then I suggest adding an FAQ entry into the manual as I imagine this will be a show-stopper for many potential users.
