### PR TITLE
Use DOI-preferred URL format for links

### DIFF
--- a/iso.bbx
+++ b/iso.bbx
@@ -149,7 +149,7 @@
 \DeclareFieldFormat{doi}{%
   \printtext{DOI}\addcolon\space%
   \ifhyperref
-    {\href{http://dx.doi.org/#1}{\nolinkurl{#1}}}
+    {\href{https://doi.org/#1}{\nolinkurl{#1}}}
     {\nolinkurl{#1}}
 }
 \DeclareFieldFormat{howpublished}{\mkbibbrackets{#1}}


### PR DESCRIPTION
Section 2.5.2.2 of the DOI® Handbook favors usage of https:// protocol over http:// and doi.org address over dx.doi.org in URLs.