### PR TITLE
Add missing bg translation.

### DIFF
--- a/bulgarian-iso.lbx
+++ b/bulgarian-iso.lbx
@@ -8,23 +8,23 @@
   at           = {{в}%
                   {в}},
   bysupervisor = {{ръководен от}%
-                  {ръководен от}},
+                  {ръков\adddotspace от}},
   url          = {{достъпен на}%
-                  {достъпен на}},
+                  {дост\adddotspace на}},
   urlalso      = {{също достъпен на}%
-                  {също достъпен на}},
-% director     = {{}%
-%                 {}},% FIXME: missing
-% bydirector   = {{}%
-%                 {}},% FIXME: missing
-% inventor     = {{}%
-%                 {}},% FIXME: missing
-% byinventor   = {{}%
-%                 {}},% FIXME: missing
-% online       = {{}%
-%                 {}},% FIXME: missing
-% film         = {{}%
-%                 {}},% FIXME: missing
+                  {също дост\adddotspace на}},
+  director     = {{режисьор}%
+                  {реж\adddot}},
+  bydirector   = {{режисиран от}%
+                  {реж\adddotspace от}},
+  inventor     = {{изобретател}%
+                  {изобр\adddot}},
+  byinventor   = {{изобретен от}%
+                  {изобр\adddotspace от}},
+  online       = {{онлайн}%
+                  {онлайн}},
+  film         = {{филм}%
+                 {филм}},
 }
 
 \endinput


### PR DESCRIPTION
I can translate `director` and `bydirector` if I know in what context they are used. I could not find this information on the internet.