### PR TITLE
Replacement: addendum -> notes

### DIFF
--- a/iso.bbx
+++ b/iso.bbx
@@ -1244,7 +1244,7 @@
     {\printfield{pagetotal}}
     {}%
   \newunit\newblock
-  \printfield{note}%
+  \printfield{addendum}%
   \newunit\newblock
   \setunit{\bibpagerefpunct}\newblock
   \usebibmacro{pageref}%
@@ -1274,7 +1274,7 @@
   \newunit\newblock
   \usebibmacro{location}%
   \newunit\newblock
-  \printfield{note}%
+  \printfield{addendum}%
   \newunit\newblock
   \setunit{\bibpagerefpunct}\newblock
   \usebibmacro{pageref}%
@@ -1309,7 +1309,7 @@
   \newunit\newblock
   \usebibmacro{location}%
   \newunit\newblock
-  \printfield{note}%
+  \printfield{addendum}%
   \setunit{\bibpagerefpunct}\newblock
   \usebibmacro{pageref}%
   \usebibmacro{finentry}}%
@@ -1350,7 +1350,7 @@
   \newunit\newblock
   \usebibmacro{location}%
   \newunit\newblock
-  \printfield{note}%
+  \printfield{addendum}%
   \newunit\newblock
   \setunit{\bibpagerefpunct}\newblock
   \usebibmacro{pageref}%
@@ -1394,7 +1394,7 @@
   \newunit\newblock
   \usebibmacro{location}%
   \newunit\newblock
-  \printfield{note}%
+  \printfield{addendum}%
   \newunit\newblock
   \setunit{\bibpagerefpunct}\newblock
   \usebibmacro{pageref}%
@@ -1429,7 +1429,7 @@
     {\printfield{pagetotal}}
     {}%
   \newunit\newblock
-  \printfield{note}%
+  \printfield{addendum}%
   \newunit\newblock
   \setunit{\bibpagerefpunct}\newblock
   \usebibmacro{pageref}%
@@ -1474,7 +1474,7 @@
      \usebibmacro{thesissupervisor}}
     {}%
   \newunit\newblock
-  \printfield{note}%
+  \printfield{addendum}%
   \newunit\newblock
   \setunit{\bibpagerefpunct}\newblock
   \usebibmacro{pageref}%
@@ -1511,7 +1511,7 @@
     {\printfield{pagetotal}}
     {}%
   \newunit\newblock
-  \printfield{note}%
+  \printfield{addendum}%
   \newunit\newblock
   \setunit{\bibpagerefpunct}\newblock
   \usebibmacro{pageref}%
@@ -1545,6 +1545,8 @@
   \usebibmacro{urldate}%
   \newunit\newblock
   \usebibmacro{availability+access}%
+  \newunit\newblock
+  \printfield{addendum}%
   \newunit\newblock
   \setunit{\bibpagerefpunct}\newblock
   \usebibmacro{pageref}%


### PR DESCRIPTION
As already discussed in the PR #99, I replaced `\printfield{note}` with `\printfield{addendum}` according to the biblatex documentation:

> note field (literal)
> Miscellaneous bibliographic data which does not fit into any other field. The note
> field may be used to record bibliographic data in a free format. Publication facts such
> as “Reprint of the edition London 1831” are typical candidates for the note field.
> See also addendum.

> addendum field (literal)
> Miscellaneous bibliographic data to be printed at the end of the entry. This is similar
> to the note field except that it is printed at the end of the bibliography entry.