### PR TITLE
Improvement: Identifiers

### DIFF
--- a/bulgarian-iso.lbx
+++ b/bulgarian-iso.lbx
@@ -13,6 +13,10 @@
                   {дост\adddotspace на}},
   urlalso      = {{също достъпен на}%
                   {също дост\adddotspace на}},
+% urlfrom      = {{}%
+%                 {}},% FIXME: missing
+% urlseen      = {{}%
+%                 {}},% FIXME: missing
   director     = {{режисьор}%
                   {реж\adddot}},
   bydirector   = {{режисиран от}%
@@ -25,6 +29,8 @@
                   {онлайн}},
   film         = {{филм}%
                   {филм}},
+% andothers    = {{}%
+%                 {}},% FIXME: missing
 % application  = {{}%
 %                 {}},% FIXME: missing
 % publication  = {{}%

--- a/czech-iso.lbx
+++ b/czech-iso.lbx
@@ -9,10 +9,12 @@
                   {v}},
   bysupervisor = {{vedouc\'{i} pr\'{a}ce}%
                   {vedouc\'{i} pr\'{a}ce}},
-  urlfrom      = {{dostupn\'{e} z}%
-                  {dostupn\'{e} z}},
   urlalso      = {{dostupn\'{e} tak\'{e} z}%
                   {dostupn\'{e} tak\'{e} z}},
+  urlfrom      = {{dostupn\'{e} z}%
+                  {dostupn\'{e} z}},
+% urlseen      = {{}%
+%                 {}},% FIXME: missing
   director     = {{re\v{z}is\'{e}r}%
                   {re\v{z}is\'{e}r}},
   bydirector   = {{re\v{z}ie}%
@@ -25,6 +27,8 @@
                   {online}},
   film         = {{film}%
                   {film}},
+% andothers    = {{}%
+%                 {}},% FIXME: missing
   application  = {{p\v{r}ihl\'{a}\v{s}ka}%
                   {p\v{r}ihl\adddot}},
   publication  = {{publikov\'{a}no}%

--- a/english-iso.lbx
+++ b/english-iso.lbx
@@ -9,8 +9,12 @@
                   {at}},
   bysupervisor = {{supervised by}%
                   {supervised by}},
-  urlalso      = {{available also from}%
-                  {available also from}},
+  urlalso      = {{also available from}%
+                  {also available from}},
+  urlfrom      = {{available from}
+                  {available from}},
+  urlseen      = {{viewed}
+                  {viewed}},
   director     = {{director}%
                   {director}},
   bydirector   = {{directed by}%
@@ -23,6 +27,8 @@
                   {online}},
   film         = {{film}%
                   {film}},
+  andothers    = {{et\addabbrvspace al\adddot}
+                  {et\addabbrvspace al\adddot}},
   application  = {{application}%
                   {appl\adddot}},
   publication  = {{publication}%

--- a/french-iso.lbx
+++ b/french-iso.lbx
@@ -18,6 +18,10 @@
                   {supervisé par}},
   urlalso      = {{aussi disponible à l'adresse}%
                   {aussi disponible à l'adresse}},
+% urlfrom      = {{}%
+%                 {}},% FIXME: missing
+% urlseen      = {{}%
+%                 {}},% FIXME: missing
   director     = {{réalisateur}%
                   {réalisateur}},
   bydirector   = {{réalisé par}%
@@ -30,6 +34,8 @@
                   {en ligne}},
   film         = {{film}%
                   {film}},
+  andothers    = {{et\addabbrvspace al\adddot}
+                  {et\addabbrvspace al\adddot}},
 % application  = {{}%
 %                 {}},% FIXME: missing
 % publication  = {{}%

--- a/german-iso.lbx
+++ b/german-iso.lbx
@@ -11,6 +11,10 @@
                   {betreut von}},
   urlalso      = {{auch verf\"{u}gbar unter}
                   {auch verf\"{u}gbar unter}},
+  urlfrom      = {{verf{\"u}gbar unter}
+                  {verf{\"u}gbar unter}},
+  urlseen      = {{Zugriff am\addcolon}
+                  {Zugriff am\addcolon}},
   director     = {{Regisseur}
                   {Regisseur}},
   bydirector   = {{Regie}
@@ -23,6 +27,8 @@
                   {online}},
   film         = {{Film}
                   {Film}},
+  andothers    = {{et\addabbrvspace al\adddot}
+                  {et\addabbrvspace al\adddot}},
   application  = {{Anmeldung}
                   {Anmeldung}},
   publication  = {{Ver\"{o}ffentlichungstag}

--- a/iso-alphabetic.dbx
+++ b/iso-alphabetic.dbx
@@ -6,7 +6,11 @@
 % Declare new fields
 \DeclareDatamodelFields[type=list, datatype=name]{supervisor}
 \DeclareDatamodelFields[type=field, datatype=literal]{dateaddon}
+\DeclareDatamodelFields[type=field, datatype=literal]{eisbn,eissn,lccn}
+\DeclareDatamodelFields[type=field, datatype=literal]{din}
 
 % Declare new fields for (specific / all) entry types
 \DeclareDatamodelEntryfields[thesis]{supervisor}
 \DeclareDatamodelEntryfields{dateaddon}
+\DeclareDatamodelEntryfields{eisbn,eissn,lccn}
+\DeclareDatamodelEntryfields[misc]{din}

--- a/iso-authortitle.dbx
+++ b/iso-authortitle.dbx
@@ -6,7 +6,11 @@
 % Declare new fields
 \DeclareDatamodelFields[type=list, datatype=name]{supervisor}
 \DeclareDatamodelFields[type=field, datatype=literal]{dateaddon}
+\DeclareDatamodelFields[type=field, datatype=literal]{eisbn,eissn,lccn}
+\DeclareDatamodelFields[type=field, datatype=literal]{din}
 
 % Declare new fields for (specific / all) entry types
 \DeclareDatamodelEntryfields[thesis]{supervisor}
 \DeclareDatamodelEntryfields{dateaddon}
+\DeclareDatamodelEntryfields{eisbn,eissn,lccn}
+\DeclareDatamodelEntryfields[misc]{din}

--- a/iso-authoryear.dbx
+++ b/iso-authoryear.dbx
@@ -6,7 +6,11 @@
 % Declare new fields
 \DeclareDatamodelFields[type=list, datatype=name]{supervisor}
 \DeclareDatamodelFields[type=field, datatype=literal]{dateaddon}
+\DeclareDatamodelFields[type=field, datatype=literal]{eisbn,eissn,lccn}
+\DeclareDatamodelFields[type=field, datatype=literal]{din}
 
 % Declare new fields for (specific / all) entry types
 \DeclareDatamodelEntryfields[thesis]{supervisor}
 \DeclareDatamodelEntryfields{dateaddon}
+\DeclareDatamodelEntryfields{eisbn,eissn,lccn}
+\DeclareDatamodelEntryfields[misc]{din}

--- a/iso-numeric.dbx
+++ b/iso-numeric.dbx
@@ -6,7 +6,11 @@
 % Declare new fields
 \DeclareDatamodelFields[type=list, datatype=name]{supervisor}
 \DeclareDatamodelFields[type=field, datatype=literal]{dateaddon}
+\DeclareDatamodelFields[type=field, datatype=literal]{eisbn,eissn,lccn}
+\DeclareDatamodelFields[type=field, datatype=literal]{din}
 
 % Declare new fields for (specific / all) entry types
 \DeclareDatamodelEntryfields[thesis]{supervisor}
 \DeclareDatamodelEntryfields{dateaddon}
+\DeclareDatamodelEntryfields{eisbn,eissn,lccn}
+\DeclareDatamodelEntryfields[misc]{din}

--- a/iso.bbx
+++ b/iso.bbx
@@ -1,6 +1,10 @@
 \ProvidesFile{iso.bbx}
   [2022/03/20 v0.4.1 ISO 690 biblatex bibliography style]
 
+
+\RequirePackage{xpatch}
+
+
 % Currently available language mappings:
 % Czech, English, German, Polish, Slovak, and more.
 % You can list them directly with `$ ls *lbx`.
@@ -285,11 +289,33 @@
   \docsvfield{isbn}%
 }
 
-% The same formatting rules as for ISBN above
+% Electronic ISBN, the same formatting rules as for ISBN above
+\DeclareFieldFormat{eisbn}{%
+  \def\do##1{\mkbibacro{eISBN}\space##1%
+    \def\do####1{\stdidentifierspunct\mkbibacro{eISBN}\space####1}}%
+  \docsvfield{eisbn}%
+}
+
+% ISSN, the same formatting rules as for ISBN above
 \DeclareFieldFormat{issn}{%
   \def\do##1{\mkbibacro{ISSN}\space##1%
     \def\do####1{\stdidentifierspunct\mkbibacro{ISSN}\space####1}}%
   \docsvfield{issn}%
+}
+
+% Electronic ISSN, the same formatting rules as for ISBN above
+\DeclareFieldFormat{eissn}{%
+  \def\do##1{\mkbibacro{eISSN}\space##1%
+    \def\do####1{\stdidentifierspunct\mkbibacro{eISSN}\space####1}}%
+  \docsvfield{issn}%
+}
+
+% LCCN
+\DeclareFieldFormat{lccn}{%
+  \mkbibacro{LCCN}\addspace
+  \ifhyperref
+    {\href{http://lccn.loc.gov/#1}{\nolinkurl{#1}}}
+    {\nolinkurl{#1}}%
 }
 
 % Format other standard identifiers
@@ -298,6 +324,18 @@
 \DeclareFieldFormat{ismn}{\mkbibacro{ISMN}\addspace#1}
 \DeclareFieldFormat{isrn}{\mkbibacro{ISRN}\addspace#1}
 \DeclareFieldFormat{iswc}{\mkbibacro{ISWC}\addspace#1}
+\DeclareFieldFormat{din}{\mkbibacro{DIN}\addspace#1}
+
+% Format for doi identifier
+\xpatchfieldformat{doi}{\mkbibacro{DOI}\addcolon\space}{\mkbibacro{doi}\addcolon}{}{}
+
+% Format for eprint identifiers
+\xpatchfieldformat{eprint}{\addcolon\space}{\addcolon}{}{}
+\xpatchfieldformat{eprint:hdl}{HDL\addcolon\space}{HDL\addcolon}{}{}
+\xpatchfieldformat{eprint:arxiv}{arXiv\addcolon\space}{arXiv\addcolon}{}{}
+\xpatchfieldformat{eprint:jstor}{JSTOR\addcolon\space}{JSTOR\addcolon}{}{}
+\xpatchfieldformat{eprint:pubmed}{PMID\addcolon\space}{PMID\addcolon}{}{}
+\xpatchfieldformat{eprint:googlebooks}{Google Books\addcolon\space}{Google Books\addcolon}{}{}
 
 % Format url seen date with preceding localisation string in square brackets
 \DeclareFieldFormat{urldate}{\mkbibbrackets{\mainlangbibstring{urlseen}\space#1}}
@@ -712,11 +750,17 @@
   \iftoggle{bbx:isbn}
     {\printfield{isan}%
      \newunit
+     \printfield{eisbn}%
+     \newunit
      \printfield{isbn}%
+     \newunit
+     \printfield{lccn}%
      \newunit
      \printfield{ismn}%
      \newunit
      \printfield{isrn}%
+     \newunit
+     \printfield{eissn}%
      \newunit
      \printfield{issn}%
      \newunit
@@ -730,8 +774,12 @@
 
 % Precedes DOI field with urlfrom localisation string
 \newbibmacro*{from-doi}{%
-  \mainlangbibstring{urlfrom}%
-  \setunit{\addspace}%
+  \ifentrytype{book}
+    {\iffieldequalstr{type}{eBook}
+      {\mainlangbibstring{urlfrom}}
+      {\mainlangbibstring{urlalso}}}
+    {\mainlangbibstring{urlfrom}}%
+  \setunit{\addcolon\space}%
   \printfield{doi}%
 }
 
@@ -739,7 +787,7 @@
 % Use default eprint formatting macro
 \newbibmacro*{from-eprint}{%
   \mainlangbibstring{urlfrom}
-  \setunit{\addspace}%
+  \setunit{\addcolon\space}%
   \usebibmacro{eprint}%
 }
 

--- a/polish-iso.lbx
+++ b/polish-iso.lbx
@@ -9,10 +9,12 @@
                   {w}},
   bysupervisor = {{promotor}%
                   {promotor}},
-  urlfrom      = {{dostępne z}%
-                  {dostępne z}},
   urlalso      = {{dostępne także z}%
                   {dostępne także z}},
+  urlfrom      = {{dostępne z}%
+                  {dostępne z}},
+% urlseen      = {{}%
+%                 {}},% FIXME: missing
 % director     = {{}%
 %                 {}},% FIXME: missing
 % bydirector   = {{}%
@@ -24,6 +26,8 @@
 % online       = {{}%
 %                 {}},% FIXME: missing
 % film         = {{}%
+%                 {}},% FIXME: missing
+% andothers    = {{}%
 %                 {}},% FIXME: missing
 % application  = {{}%
 %                 {}},% FIXME: missing

--- a/slovak-iso.lbx
+++ b/slovak-iso.lbx
@@ -11,6 +11,10 @@
                   {ved\'{u}ci pr\'{a}ce}},
   urlalso      = {{dostupn\'{e} tie\v{z} z}%
                   {dostupn\'{e} tie\v{z} z}},
+% urlfrom      = {{}%
+%                 {}},% FIXME: missing
+% urlseen      = {{}%
+%                 {}},% FIXME: missing
   director     = {{re\v{z}is\'{e}r}%
                   {re\v{z}is\'{e}r}},
   bydirector   = {{r\'{e}\v{z}ia}%
@@ -23,6 +27,8 @@
                   {online}},
   film         = {{film}%
                   {film}},
+% andothers    = {{}%
+%                 {}},% FIXME: missing
   application  = {{prihl\'{a}\v{s}ka}%
                   {prihl\adddot}},
   publication  = {{publikovan\'{e}}%

--- a/spanish-iso.lbx
+++ b/spanish-iso.lbx
@@ -11,6 +11,10 @@
                   {supervisado por}},
   urlalso      = {{disponible también desde}%
                   {disponible también desde}},
+% urlfrom      = {{}%
+%                 {}},% FIXME: missing
+% urlseen      = {{}%
+%                 {}},% FIXME: missing
   director     = {{director}%
                   {director}},
   bydirector   = {{dirigido por}%
@@ -25,7 +29,6 @@
                   {film}},
   andothers    = {{et\addabbrvspace al\adddot}%
                   {et\addabbrvspace al\adddot}},
-  % if not, y col. will be used instead of et al.
 % application  = {{}%
 %                 {}},% FIXME: missing
 % publication  = {{}%


### PR DESCRIPTION
I added the identifiers eisbn, eissn, lccn and din.
Moreover I added the bibstrings `urlfrom`, `urlseen` and `andothers` to those languages where the were not already defined anyway. Of course, I did not dare to translate other languages here. For german and english I just took the exact expression as given in the corresponding iso 690 document.
I also took a very close look at the punctuation and made it exactly the same as given in the iso 690 document.