### PR TITLE
Extension: New bibmacro refreshdate + copyrightsymbol

### DIFF
--- a/biblatex-iso690-examples.bib
+++ b/biblatex-iso690-examples.bib
@@ -464,6 +464,20 @@
   note         = {Technical Memo 5},
 }
 
+% refreshdate + copyright symbol example
+@manual{idoifoundation,
+  author          = {{International DOI Foundation}},
+  title           = {DOI Handbook},
+  origdate        = {2006},
+  origdate+an     = {=copyright},
+
+  type            = {online},
+  date            = {2007-09-19},
+  urldate         = {2008-05-20},
+  url             = {http://www.doi.org/hb.html},
+  langid          = {english}
+}
+
 % currentlang package option example 1
 @article{tex:zpravodajchlebikova91,
   author  = {Chlebíková, Jana},

--- a/bulgarian-iso.lbx
+++ b/bulgarian-iso.lbx
@@ -9,13 +9,13 @@
                   {в}},
   bysupervisor = {{ръководен от}%
                   {ръков\adddotspace от}},
-  url          = {{достъпен на}%
-                  {дост\adddotspace на}},
   urlalso      = {{също достъпен на}%
                   {също дост\adddotspace на}},
 % urlfrom      = {{}%
 %                 {}},% FIXME: missing
 % urlseen      = {{}%
+%                 {}},% FIXME: missing
+% refreshedon  = {{}%
 %                 {}},% FIXME: missing
   director     = {{режисьор}%
                   {реж\adddot}},

--- a/czech-iso.lbx
+++ b/czech-iso.lbx
@@ -15,6 +15,8 @@
                   {dostupn\'{e} z}},
 % urlseen      = {{}%
 %                 {}},% FIXME: missing
+% refreshedon  = {{}%
+%                 {}},% FIXME: missing
   director     = {{re\v{z}is\'{e}r}%
                   {re\v{z}is\'{e}r}},
   bydirector   = {{re\v{z}ie}%

--- a/english-iso.lbx
+++ b/english-iso.lbx
@@ -15,6 +15,8 @@
                   {available from}},
   urlseen      = {{viewed}
                   {viewed}},
+  refreshedon  = {{updated}
+                  {updated}},
   director     = {{director}%
                   {director}},
   bydirector   = {{directed by}%

--- a/french-iso.lbx
+++ b/french-iso.lbx
@@ -22,6 +22,8 @@
 %                 {}},% FIXME: missing
 % urlseen      = {{}%
 %                 {}},% FIXME: missing
+% refreshedon  = {{}%
+%                 {}},% FIXME: missing
   director     = {{réalisateur}%
                   {réalisateur}},
   bydirector   = {{réalisé par}%

--- a/german-iso.lbx
+++ b/german-iso.lbx
@@ -15,6 +15,8 @@
                   {verf{\"u}gbar unter}},
   urlseen      = {{Zugriff am\addcolon}
                   {Zugriff am\addcolon}},
+  refreshedon  = {{aktualisiert am}
+                  {aktualisiert am}},
   director     = {{Regisseur}
                   {Regisseur}},
   bydirector   = {{Regie}

--- a/iso-authoryear.bbx
+++ b/iso-authoryear.bbx
@@ -31,7 +31,7 @@
     {\printfield{dateaddon}}%
 }
 
-% Check if 'date' field holds only year or a more specific date.
+% Check if 'date' or 'origdate' field holds only year or a more specific date.
 % Inspired by \ifdatehasyearonlyprecision from 'biblatex.sty',
 % but the test date==year is left out, because we use date=year
 % in package options so it turned always true.
@@ -40,14 +40,23 @@
               and (test {\iffieldundef{month}}
                    and test {\iffieldundef{season}})}
 }
+\newcommand{\iforigdatehasyearonly}{%
+  \ifboolexpr{not test {\iffieldundef{origyear}}
+              and (test {\iffieldundef{origmonth}}
+                   and test {\iffieldundef{origseason}})}
+}
 
 % If there is no more specific date available, we shouldn't repeat
 % the year in publication info section.
 % Overrides macro 'fulldate' in 'iso.bbx'.
 \renewbibmacro*{fulldate}{%
-  \ifdatehasyearonly%
-    {}% Print nothing (only year is available)
-    {\mkdaterangeiso{}}%
+  \iffieldundef{origyear}
+    {\ifdatehasyearonly%
+      {}% Print nothing (only year is available)
+      {\mkdaterangeiso{}}}
+    {\iforigdatehasyearonly
+      {}% Print nothing (only origyear is available)
+      {\mkdaterangeiso{orig}}}%
 }
 
 % Remove second appearance of year in a reference

--- a/iso.bbx
+++ b/iso.bbx
@@ -12,7 +12,7 @@
 % https://github.com/michal-h21/biblatex-iso690/wiki/Translation-Guideline#translation-matrix
 \DeclareLanguageMappingSuffix{-iso}
 % Currently needed the following additional language strings:
-\NewBibliographyString{at,bysupervisor,urlalso,
+\NewBibliographyString{at,bysupervisor,urlalso,refreshedon,
   director,bydirector,inventor,byinventor,online,film,application,publication}
 
 % PACKAGE OPTIONS
@@ -364,8 +364,18 @@
 \DeclareFieldFormat{date}{%
   \ifdatecirca
     {\mkbibbrackets{#1}}%
-    {#1}%
+    {\ifdateannotation{date}{copyright}
+      {\textcopyright\addnbthinspace#1}
+      {#1}}%
 }
+\DeclareFieldFormat{origdate}{%
+  \ifdatecirca
+    {\mkbibbrackets{#1}}%
+    {\ifdateannotation{origdate}{copyright}
+      {\textcopyright\addnbthinspace#1}
+      {#1}}%
+}
+
 
 % Format 'labeldate' the same as 'date' field.
 % We use 'labeldate' in 'iso-authoryear' style.
@@ -378,7 +388,18 @@
         % This is a \literal{nodate}, meaning that it uses the 'nodate'
         % localisation string due to default \DeclareLabeldate setting
         {\mkbibbrackets{#1}}%
-        {#1}}% This is the go-to format
+        {\ifboolexpr{(test {\iffieldundef{origyear}} and
+        test {\ifdateannotation{date}{copyright}}) or
+        (not test {\iffieldundef{origyear}} and
+        test {\ifdateannotation{origdate}{copyright}})}
+          {\textcopyright\addnbthinspace#1}
+          {#1}}}% This is the go-to format
+}
+\AtEveryCite{%
+\DeclareFieldFormat{labeldate}{%
+  \iffieldequalstr{labeldatesource}{nodate}
+    {\mkbibbrackets{#1}}%
+    {#1}}%
 }
 
 % Define names to consider for 'labelname', based on
@@ -658,6 +679,16 @@
 }
 
 
+% EDITION INFO MACROS
+
+% Refresh date
+\newbibmacro{refreshdate}{%
+  % the date is only supposed to be a refreshdate
+  % if we have an origdate
+  \iffieldundef{origyear}
+    {}
+    {\mainlangbibstring{refreshedon}\space\printdate}
+}
 
 
 % PUBLICATION INFO MACROS
@@ -1301,6 +1332,8 @@
   \usebibmacro{medium-type}%
   \newunit\newblock
   \printfield{edition}%
+  \newunit
+  \usebibmacro{refreshdate}%
   \newunit\newblock
   \usebibmacro{names:subsidiary}%
   \newunit\newblock
@@ -1341,6 +1374,8 @@
   \usebibmacro{medium-type}%
   \newunit\newblock
   \printfield{edition}%
+  \newunit
+  \usebibmacro{refreshdate}%
   \newunit\newblock
   \usebibmacro{location+publisher+date}%
   \setunit{\numerationpunct}%
@@ -1372,6 +1407,8 @@
   \usebibmacro{medium-type}%
   \newunit\newblock
   \printfield{edition}%
+  \newunit
+  \usebibmacro{refreshdate}%
   \newunit\newblock
   \iftoggle{bbx:articlepubinfo}
     {\usebibmacro{location+publisher+date}}
@@ -1409,6 +1446,8 @@
   \usebibmacro{medium-type}%
   \newunit\newblock
   \printfield{edition}%
+  \newunit
+  \usebibmacro{refreshdate}%
   \newunit\newblock
   \usebibmacro{names:subsidiary}%
   \newunit\newblock
@@ -1451,6 +1490,8 @@
   \usebibmacro{medium-type}%
   \newunit\newblock
   \printfield{edition}%
+  \newunit
+  \usebibmacro{refreshdate}%
   \newunit\newblock
   \usebibmacro{names:subsidiary}%
   \newunit\newblock
@@ -1495,6 +1536,8 @@
   \usebibmacro{medium-type}%
   \newunit\newblock
   \printfield{edition}%
+  \newunit
+  \usebibmacro{refreshdate}%
   \newunit\newblock
   \usebibmacro{names:subsidiary}%
   \newunit\newblock
@@ -1543,6 +1586,8 @@
   \usebibmacro{medium-type}%
   \newunit\newblock
   \printfield{edition}%
+  \newunit
+  \usebibmacro{refreshdate}%
   \newunit\newblock
   \usebibmacro{names:subsidiary}%
   \newunit\newblock
@@ -1586,6 +1631,8 @@
   \usebibmacro{medium-type}%
   \newunit\newblock
   \printfield{edition}%
+  \newunit
+  \usebibmacro{refreshdate}%
   \newunit\newblock
   \usebibmacro{names:subsidiary}%
   \newunit\newblock
@@ -1664,6 +1711,8 @@
   \usebibmacro{titles}{}{emph}%
   \setunit{\addspace}%
   \usebibmacro{medium-type}%
+  \newunit\newblock
+  \usebibmacro{refreshdate}%
   \newunit\newblock
   \usebibmacro{location+publisher+fulldate}%
   \newunit

--- a/polish-iso.lbx
+++ b/polish-iso.lbx
@@ -15,6 +15,8 @@
                   {dostępne z}},
 % urlseen      = {{}%
 %                 {}},% FIXME: missing
+% refreshedon  = {{}%
+%                 {}},% FIXME: missing
 % director     = {{}%
 %                 {}},% FIXME: missing
 % bydirector   = {{}%

--- a/slovak-iso.lbx
+++ b/slovak-iso.lbx
@@ -15,6 +15,8 @@
 %                 {}},% FIXME: missing
 % urlseen      = {{}%
 %                 {}},% FIXME: missing
+% refreshedon  = {{}%
+%                 {}},% FIXME: missing
   director     = {{re\v{z}is\'{e}r}%
                   {re\v{z}is\'{e}r}},
   bydirector   = {{r\'{e}\v{z}ia}%

--- a/spanish-iso.lbx
+++ b/spanish-iso.lbx
@@ -15,6 +15,8 @@
 %                 {}},% FIXME: missing
 % urlseen      = {{}%
 %                 {}},% FIXME: missing
+% refreshedon  = {{}%
+%                 {}},% FIXME: missing
   director     = {{director}%
                   {director}},
   bydirector   = {{dirigido por}%


### PR DESCRIPTION
According to section 8.2 of the ISO 690-2010, I added a new bibmacro called `refreshdate`.
Moreover I made it possible to add a copyright symbol in front of the date. The example given in the document in that section can now be realised as follows:
```
@manual{idoifoundation,
  editor          = {{International DOI Foundation}},
  title           = {DOI Handbook},
  origdate        = {2006},
  origdate+an     = {=copyright},

  type            = {online},
  date            = {2007-09-19},
  urldate         = {2008-05-20},
  url             = {http://www.doi.org/hb.html},
  langid          = {english}
}
```
Note that, similar to the patent entrytype, the `origdate` field becomes the primary date here and the `date` field is used as the refresh date. The copyright symbol is implemented by using data field annotations as described under 3.7 in the latest biblatex manual.