### PR TITLE
Making givennamesfirst option work again

### DIFF
--- a/iso.bbx
+++ b/iso.bbx
@@ -99,7 +99,7 @@
   \settoggle{bbx:familynamesc}{#1}%
   \isoblx@info@noline{Printing family names as textsc enabled: #1}}
 \DeclareBibliographyOption{givennamesfirst}[true]{%
-  \global\settoggle{bbx:givennamesfirst}{#1}%
+  \settoggle{bbx:givennamesfirst}{#1}%
   \isoblx@info@noline{Printing names as 'given family' except for the first author: #1}}
 
 
@@ -557,8 +557,10 @@
     % Default name list format is last (family) followed by first (given) name
     {family-given}%
 }
-\DeclareNameAlias{default}{\mknamealias}
-\DeclareNameAlias{sortname}{\mksortnamealias}
+\AtEndOfPackage{%
+\DeclareNameAlias{default}{\mknamealias}%
+\DeclareNameAlias{sortname}{\mksortnamealias}%
+}
 \DeclareNameAlias{author}{sortname}
 \DeclareNameAlias{editor}{sortname}
 \DeclareNameAlias[patent]{holder}{sortname}


### PR DESCRIPTION
I figured that the `givennamesfirst` option does not work correctly altough I could swear that everything was fine when testing it before I commited that PR. I can remember that it was tricky to make that work and that's the reason why I worked with `global` back then. Maybe something has changed interanlly so that this does not work anymore or maybe it never worked corretly, i don't know.
Bascially the problem here is the order of exectution during the compilation process. When calling the package with
```latex
\usepackage[backend=biber, givennamesfirst=true]{biblatex}
```
the option `givennamesfirst=true` is not being executed before the lines 560 and 561
```latex
\DeclareNameAlias{default}{\mknamealias}%
\DeclareNameAlias{sortname}{\mksortnamealias}%
```
are executed, which means that theses lines are always executed with `givennamesfirst=false` as set as default option in line 132, no matter how you call the package. The incorrect values for `default` and `sortname` are then already saved and will not be changed anymore even if the package option `givennamesfirst=true` is being executed later on.
Long story short, we need the `\AtEndOfPackage` hook here to delay that execution.